### PR TITLE
fix libtmux deprecation warning when killing session

### DIFF
--- a/tmux-mpi
+++ b/tmux-mpi
@@ -94,7 +94,7 @@ class TMUXSession:
             wx.enter()
 
     def kill_session(self):
-        self.tmux_session.kill_session()
+        self.tmux_session.kill()
 
     def set_sync_panes(self):
         self.tmux_session.set_option("synchronize-panes", "on")


### PR DESCRIPTION
see comment: https://github.com/wrs20/tmux-mpi/issues/2#issuecomment-1951444973

Tested on my machine, fixes the deprecation warning